### PR TITLE
8 add the token enrollment via validatecheck

### DIFF
--- a/PrivacyIDEA_Client/PIChallenge.cs
+++ b/PrivacyIDEA_Client/PIChallenge.cs
@@ -8,6 +8,7 @@ namespace PrivacyIDEA_Client
         public string Message { get; set; } = "";
         public string TransactionID { get; set; } = "";
         public string Type { get; set; } = "";
+        public string Img { get; set; } = "";
         public Dictionary<string, object> Attributes { get; set; } = new Dictionary<string, object>();
     }
 }

--- a/PrivacyIDEA_Client/PIChallenge.cs
+++ b/PrivacyIDEA_Client/PIChallenge.cs
@@ -5,6 +5,7 @@
         public string Serial { get; set; } = "";
         public string Message { get; set; } = "";
         public string TransactionID { get; set; } = "";
+        public string ClientMode { get; set; } = "";
         public string Type { get; set; } = "";
         public string Image { get; set; } = "";
         public Dictionary<string, object> Attributes { get; set; } = new Dictionary<string, object>();

--- a/PrivacyIDEA_Client/PIChallenge.cs
+++ b/PrivacyIDEA_Client/PIChallenge.cs
@@ -5,7 +5,6 @@
         public string Serial { get; set; } = "";
         public string Message { get; set; } = "";
         public string TransactionID { get; set; } = "";
-        public string ClientMode { get; set; } = "";
         public string Type { get; set; } = "";
         public string Image { get; set; } = "";
         public Dictionary<string, object> Attributes { get; set; } = new Dictionary<string, object>();

--- a/PrivacyIDEA_Client/PIChallenge.cs
+++ b/PrivacyIDEA_Client/PIChallenge.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace PrivacyIDEA_Client
+﻿namespace PrivacyIDEA_Client
 {
     public class PIChallenge
     {
@@ -8,7 +6,7 @@ namespace PrivacyIDEA_Client
         public string Message { get; set; } = "";
         public string TransactionID { get; set; } = "";
         public string Type { get; set; } = "";
-        public string Img { get; set; } = "";
+        public string Image { get; set; } = "";
         public Dictionary<string, object> Attributes { get; set; } = new Dictionary<string, object>();
     }
 }

--- a/PrivacyIDEA_Client/PIResponse.cs
+++ b/PrivacyIDEA_Client/PIResponse.cs
@@ -154,9 +154,12 @@ namespace PrivacyIDEA_Client
                     {
                         foreach (JToken element in multiChallenge.Children())
                         {
+                            if ((string?)element["image"] is string img)
+                            {
+                                string chalImage = img;
+                            }
                             if ((string?)element["message"] is string chalMessage && (string?)element["transaction_id"] is string chalTransactionID
-                                && (string?)element["type"] is string chalType && (string?)element["image"] is string chalImage
-                                && (string?)element["serial"] is string chalSerial)
+                                && (string?)element["type"] is string chalType && (string?)element["serial"] is string chalSerial)
                             {
                                 if (chalType == "webauthn")
                                 {
@@ -176,7 +179,6 @@ namespace PrivacyIDEA_Client
                                     tmp.Serial = chalSerial;
                                     tmp.TransactionID = chalTransactionID;
                                     tmp.Type = chalType;
-                                    tmp.Image = chalImage;
                                     ret.Challenges.Add(tmp);
                                 }
                                 else

--- a/PrivacyIDEA_Client/PIResponse.cs
+++ b/PrivacyIDEA_Client/PIResponse.cs
@@ -160,7 +160,6 @@ namespace PrivacyIDEA_Client
                                 chalImage = img;
                             }
                             if ((string?)element["message"] is string chalMessage 
-                                && (string?)element["client_mode"] is string chalClientMode
                                 && (string?)element["transaction_id"] is string chalTransactionID
                                 && (string?)element["type"] is string chalType 
                                 && (string?)element["serial"] is string chalSerial)
@@ -182,7 +181,6 @@ namespace PrivacyIDEA_Client
                                     {
                                         Image = chalImage,
                                         Message = chalMessage,
-                                        ClientMode = chalClientMode,
                                         Serial = chalSerial,
                                         TransactionID = chalTransactionID,
                                         WebAuthnSignRequest = webAuthnSignRequest,
@@ -196,7 +194,6 @@ namespace PrivacyIDEA_Client
                                     {
                                         Message = chalMessage,
                                         Serial = chalSerial,
-                                        ClientMode = chalClientMode,
                                         Image = chalImage,
                                         TransactionID = chalTransactionID,
                                         Type = chalType

--- a/PrivacyIDEA_Client/PIResponse.cs
+++ b/PrivacyIDEA_Client/PIResponse.cs
@@ -7,7 +7,6 @@ namespace PrivacyIDEA_Client
     {
         public string TransactionID { get; set; } = "";
         public string Message { get; set; } = "";
-        public string Image { get; set; } = "";
         public string PreferredClientMode { get; set; } = "";
         public string? ErrorMessage { get; set; } = "";
         public string Type { get; set; } = "";
@@ -142,10 +141,6 @@ namespace PrivacyIDEA_Client
                     {
                         ret.Message = message;
                     }
-                    if ((string?)detail["image"] is string image)
-                    {
-                        ret.Image = image;
-                    }
                     if ((string?)detail["type"] is string type)
                     {
                         ret.Type = type;
@@ -160,7 +155,8 @@ namespace PrivacyIDEA_Client
                         foreach (JToken element in multiChallenge.Children())
                         {
                             if ((string?)element["message"] is string chalMessage && (string?)element["transaction_id"] is string chalTransactionID
-                                && (string?)element["type"] is string chalType && (string?)element["serial"] is string chalSerial)
+                                && (string?)element["type"] is string chalType && (string?)element["image"] is string chalImage
+                                && (string?)element["serial"] is string chalSerial)
                             {
                                 if (chalType == "webauthn")
                                 {
@@ -168,11 +164,6 @@ namespace PrivacyIDEA_Client
 
                                     if (element["attributes"] is JToken attr && attr.Type is not JTokenType.Null)
                                     {
-                                        if (attr["img"] is JToken img && img.Type is not JTokenType.Null)
-                                        {
-                                            tmp.Img = img.ToString();
-                                        }
-
                                         var signRequest = attr["webAuthnSignRequest"];
                                         if (signRequest is not null)
                                         {
@@ -185,6 +176,7 @@ namespace PrivacyIDEA_Client
                                     tmp.Serial = chalSerial;
                                     tmp.TransactionID = chalTransactionID;
                                     tmp.Type = chalType;
+                                    tmp.Image = chalImage;
                                     ret.Challenges.Add(tmp);
                                 }
                                 else

--- a/PrivacyIDEA_Client/PIResponse.cs
+++ b/PrivacyIDEA_Client/PIResponse.cs
@@ -7,6 +7,7 @@ namespace PrivacyIDEA_Client
     {
         public string TransactionID { get; set; } = "";
         public string Message { get; set; } = "";
+        public string Image { get; set; } = "";
         public string PreferredClientMode { get; set; } = "";
         public string? ErrorMessage { get; set; } = "";
         public string Type { get; set; } = "";
@@ -141,6 +142,10 @@ namespace PrivacyIDEA_Client
                     {
                         ret.Message = message;
                     }
+                    if ((string?)detail["image"] is string image)
+                    {
+                        ret.Image = image;
+                    }
                     if ((string?)detail["type"] is string type)
                     {
                         ret.Type = type;
@@ -163,6 +168,11 @@ namespace PrivacyIDEA_Client
 
                                     if (element["attributes"] is JToken attr && attr.Type is not JTokenType.Null)
                                     {
+                                        if (attr["img"] is JToken img && img.Type is not JTokenType.Null)
+                                        {
+                                            tmp.Img = img.ToString();
+                                        }
+
                                         var signRequest = attr["webAuthnSignRequest"];
                                         if (signRequest is not null)
                                         {

--- a/PrivacyIDEA_Client/PIResponse.cs
+++ b/PrivacyIDEA_Client/PIResponse.cs
@@ -154,31 +154,40 @@ namespace PrivacyIDEA_Client
                     {
                         foreach (JToken element in multiChallenge.Children())
                         {
+                            string chalImage = "";
                             if ((string?)element["image"] is string img)
                             {
-                                string chalImage = img;
+                                chalImage = img;
                             }
-                            if ((string?)element["message"] is string chalMessage && (string?)element["transaction_id"] is string chalTransactionID
-                                && (string?)element["type"] is string chalType && (string?)element["serial"] is string chalSerial)
+                            if ((string?)element["message"] is string chalMessage 
+                                && (string?)element["client_mode"] is string chalClientMode
+                                && (string?)element["transaction_id"] is string chalTransactionID
+                                && (string?)element["type"] is string chalType 
+                                && (string?)element["serial"] is string chalSerial)
                             {
                                 if (chalType == "webauthn")
                                 {
-                                    PIWebAuthnSignRequest tmp = new();
-
+                                    string webAuthnSignRequest = "";
                                     if (element["attributes"] is JToken attr && attr.Type is not JTokenType.Null)
                                     {
                                         var signRequest = attr["webAuthnSignRequest"];
                                         if (signRequest is not null)
                                         {
-                                            tmp.WebAuthnSignRequest = signRequest.ToString(Formatting.None);
-                                            _ = tmp.WebAuthnSignRequest.Replace("\n", "");
+                                            webAuthnSignRequest = signRequest.ToString(Formatting.None)
+                                                                                 .Replace("\n", "");
                                         }
                                     }
 
-                                    tmp.Message = chalMessage;
-                                    tmp.Serial = chalSerial;
-                                    tmp.TransactionID = chalTransactionID;
-                                    tmp.Type = chalType;
+                                    PIWebAuthnSignRequest tmp = new()
+                                    {
+                                        Image = chalImage,
+                                        Message = chalMessage,
+                                        ClientMode = chalClientMode,
+                                        Serial = chalSerial,
+                                        TransactionID = chalTransactionID,
+                                        WebAuthnSignRequest = webAuthnSignRequest,
+                                        Type = chalType,
+                                    };
                                     ret.Challenges.Add(tmp);
                                 }
                                 else
@@ -187,6 +196,8 @@ namespace PrivacyIDEA_Client
                                     {
                                         Message = chalMessage,
                                         Serial = chalSerial,
+                                        ClientMode = chalClientMode,
+                                        Image = chalImage,
                                         TransactionID = chalTransactionID,
                                         Type = chalType
                                     };

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -218,6 +218,7 @@ namespace Tests
                                 "  \"detail\": {\n" +
                                 "    \"preferred_client_mode\": \"push\",\n" +
                                 "    \"attributes\": null,\n" +
+                                "    \"image\": \"imgdata123ß0i194021123\",\n" +
                                 "    \"message\": \"Bitte geben Sie einen OTP-Wert ein: , Please confirm the authentication on your mobile device!\",\n" +
                                 "    \"messages\": [\n" +
                                 "      \"Bitte geben Sie einen OTP-Wert ein: \",\n" +
@@ -291,6 +292,7 @@ namespace Tests
             Assert.AreEqual(true, resp.Status);
             Assert.AreEqual("02659936574063359702", resp.TransactionID);
             Assert.AreEqual("push", resp.PreferredClientMode);
+            Assert.AreEqual("imgdata123ß0i194021123", resp.Image);
             Assert.AreEqual("Bitte geben Sie einen OTP-Wert ein: , Please confirm the authentication on your mobile device!", resp.Message);
 
             Assert.IsTrue(resp.TriggeredTokenTypes().Contains("push"));
@@ -309,6 +311,7 @@ namespace Tests
 
             var c3 = resp.Challenges.Find(item => item.Type == "webauthn");
             Assert.AreEqual("WAN00025CE7", c3.Serial);
+            Assert.AreEqual("static/img/FIDO-U2F-Security-Key-444x444.png", c3.Img);
             Assert.AreEqual("Please confirm with your WebAuthn token (Yubico U2F EE Serial 61730834)", c3.Message);
             var signRequest = resp.MergedSignRequest();
             Assert.IsFalse(string.IsNullOrEmpty(signRequest));

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -218,7 +218,6 @@ namespace Tests
                                 "  \"detail\": {\n" +
                                 "    \"preferred_client_mode\": \"push\",\n" +
                                 "    \"attributes\": null,\n" +
-                                "    \"image\": \"imgdata123ß0i194021123\",\n" +
                                 "    \"message\": \"Bitte geben Sie einen OTP-Wert ein: , Please confirm the authentication on your mobile device!\",\n" +
                                 "    \"messages\": [\n" +
                                 "      \"Bitte geben Sie einen OTP-Wert ein: \",\n" +
@@ -292,7 +291,6 @@ namespace Tests
             Assert.AreEqual(true, resp.Status);
             Assert.AreEqual("02659936574063359702", resp.TransactionID);
             Assert.AreEqual("push", resp.PreferredClientMode);
-            Assert.AreEqual("imgdata123ß0i194021123", resp.Image);
             Assert.AreEqual("Bitte geben Sie einen OTP-Wert ein: , Please confirm the authentication on your mobile device!", resp.Message);
 
             Assert.IsTrue(resp.TriggeredTokenTypes().Contains("push"));
@@ -311,7 +309,6 @@ namespace Tests
 
             var c3 = resp.Challenges.Find(item => item.Type == "webauthn");
             Assert.AreEqual("WAN00025CE7", c3.Serial);
-            Assert.AreEqual("static/img/FIDO-U2F-Security-Key-444x444.png", c3.Img);
             Assert.AreEqual("Please confirm with your WebAuthn token (Yubico U2F EE Serial 61730834)", c3.Message);
             var signRequest = resp.MergedSignRequest();
             Assert.IsFalse(string.IsNullOrEmpty(signRequest));


### PR DESCRIPTION
NOTE: Merge the other PR's first.

1. Add the QR image to PIResponse object.
2. Add challenge img to Challenge object.
3. Update tests.

Question: Some `challenges` contain an image. Those images can be found in the challenge's `attributes` in the server response. These are other images than the QR Codes placed in the `detail` section on the top of the server response.
Is it a good idea to add these images to single Challenge objects? Should we allow providers to show them in UI?
This version forwards the `images` found in each `challenge`. Should it stay so? Use of it is not required.
 @nilsbehlen 